### PR TITLE
fixing error with double quotes sent to API

### DIFF
--- a/src/app/Controllers/Records.php
+++ b/src/app/Controllers/Records.php
@@ -39,6 +39,7 @@ class Records extends BaseController
 		$this->data['speciesNameType'] = !empty(get_cookie('nameType')) ? get_cookie('nameType') : 'scientific' ;
 		$this->data['speciesGroup'] = !empty(get_cookie('speciesGroup')) ? get_cookie('speciesGroup') : 'both' ;
 		$this->data['axiophyteFilter'] = !empty(get_cookie('axiophyteFilter')) ? get_cookie('axiophyteFilter') : 'false' ;
+
 		echo view('species_records', $this->data);
 	}
 

--- a/src/app/Models/NbnQuery.php
+++ b/src/app/Models/NbnQuery.php
@@ -138,11 +138,12 @@ class NbnQuery implements NbnQueryInterface
 		$nbnRecords->dir  = "desc";
 		// $nbnRecords->fsort = "index";
 		$nbnRecords
-			->add('taxon_name:' . '"' . $speciesName . '"');
+			->add('taxon_name:' . '%22' . $speciesName . '%22');
 		$queryUrl           = $nbnRecords->getPagingQueryStringWithStart($page);
 
 		$nbnQueryResponse = $this->callNbnApi($queryUrl);
 		$speciesQueryResult               = new NbnQueryResult();
+		echo(var_dump($nbnQueryResponse));
 		if ($nbnQueryResponse->status === 'OK' )
 		{
 			$recordList         = $nbnQueryResponse->jsonResponse->occurrences;
@@ -350,8 +351,8 @@ class NbnQuery implements NbnQueryInterface
 		$nbnRecords->dir  = "desc";
 		// $nbnRecords->fsort = "index";
 		$nbnRecords
-			->add('taxon_name:' . '"' . $speciesName . '"')
-			->add('location_id:' . '"' . urlencode($siteName) . '"');
+			->add('taxon_name:' . '%22' . $speciesName . '%22')
+			->add('location_id:' . '%22' . urlencode($siteName) . '%22');
 		$queryUrl           = $nbnRecords->getPagingQueryStringWithStart($page);
 		$recordsJson        = file_get_contents($queryUrl);
 		$recordsJsonDecoded = json_decode($recordsJson);
@@ -470,8 +471,8 @@ class NbnQuery implements NbnQueryInterface
 		$nbnRecords->sort = "year";
 		$nbnRecords->dir  = "desc";
 		$nbnRecords
-			->add('taxon_name:' . '"' . $speciesName . '"')
-			->add('grid_ref_1000:' . '"' . urlencode($gridSquare) . '"');
+			->add('taxon_name:' . '%22' . $speciesName . '%22')
+			->add('grid_ref_1000:' . '%22' . urlencode($gridSquare) . '%22');
 		$queryUrl           = $nbnRecords->getPagingQueryStringWithStart($page);
 
 		$nbnQueryResponse 	= $this->callNbnApi($queryUrl);


### PR DESCRIPTION
Double quotes in strings are no longer accepted by the NBN API, and causing queries to fail on the site.  Using %22 works, so have shifted to that.